### PR TITLE
Fix global Terraform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.1.1]
+
+Fix global terraform version by fallback to `terraform.exe` from path and reload path.
+
 ## [0.1.0]
 
 Added option to set a global terraform version by adding to user's path. This should work with external applications like VSCode.

--- a/WTerraform/Public/Invoke-WTerraform.ps1
+++ b/WTerraform/Public/Invoke-WTerraform.ps1
@@ -9,17 +9,22 @@ Invoke-WTerraform -version
 Throws error if no Terraform Version was specified earlier. Otherwise runs command 'terraform -version'
 #>
 function Invoke-WTerraform {
-    $version = Get-WTerraformVersion
-    if ($version) {
-        $path = Join-Path -Path $env:LOCALAPPDATA -ChildPath "WTerraform" | Join-Path -ChildPath $version | Join-Path -ChildPath "terraform.exe"
-        if (Test-Path -LiteralPath $path) {
-            & $path $args
-        } else {
-            #TODO: Redownload terraform
-            throw "$version is not found"
+    $pwdVersion = Get-WTerraformVersion
+    $wTerraformPath = Join-Path -Path $env:LOCALAPPDATA -ChildPath "WTerraform"
+    if ($pwdVersion) {
+        $path =  Join-Path -Path $wTerraformPath -ChildPath $pwdVersion | Join-Path -ChildPath "terraform.exe"
+    } elseif ($terraformCommand = Get-Command -Name "terraform.exe" -CommandType Application -ErrorAction SilentlyContinue) {
+        $path = $terraformCommand.Source
+        if (-not $path.StartsWith($wTerraformPath)) {
+            Write-Warning -Message "Using terraform in $path. This is not installed by WTerraform!"
         }
-
     } else {
         throw "No Version for $pwd specified. Please Run Set-WTerraformVersion."
+    }
+    if (Test-Path -LiteralPath $path) {
+        & $path $args
+    } else {
+        #TODO: Redownload terraform
+        throw "$pwdVersion is not found"
     }
 }

--- a/WTerraform/Public/Set-WTerraformVersion.ps1
+++ b/WTerraform/Public/Set-WTerraformVersion.ps1
@@ -44,6 +44,7 @@ function Set-WTerraformVersion {
             }
             $path = $path + ";" + $versionPath
             [System.Environment]::SetEnvironmentVariable("Path", $path, [System.EnvironmentVariableTarget]::User)
+            $env:Path = [System.Environment]::SetEnvironmentVariable("Path", $path, [System.EnvironmentVariableTarget]::Machine) + ";"+  [System.Environment]::SetEnvironmentVariable("Path", $path, [System.EnvironmentVariableTarget]::User)
         } else {
             $versionMap = Get-WTerraformVersionMap
             $oldVersion = Get-WTerraformversion

--- a/WTerraform/Public/Set-WTerraformVersion.ps1
+++ b/WTerraform/Public/Set-WTerraformVersion.ps1
@@ -44,7 +44,7 @@ function Set-WTerraformVersion {
             }
             $path = $path + ";" + $versionPath
             [System.Environment]::SetEnvironmentVariable("Path", $path, [System.EnvironmentVariableTarget]::User)
-            $env:Path = [System.Environment]::SetEnvironmentVariable("Path", $path, [System.EnvironmentVariableTarget]::Machine) + ";"+  [System.Environment]::SetEnvironmentVariable("Path", $path, [System.EnvironmentVariableTarget]::User)
+            $env:Path = [System.Environment]::GetEnvironmentVariable("Path", [System.EnvironmentVariableTarget]::Machine) + ";"+  [System.Environment]::GetEnvironmentVariable("Path", [System.EnvironmentVariableTarget]::User)
         } else {
             $versionMap = Get-WTerraformVersionMap
             $oldVersion = Get-WTerraformversion

--- a/WTerraform/WTerraform.psd1
+++ b/WTerraform/WTerraform.psd1
@@ -11,7 +11,7 @@
     RootModule            = 'WTerraform.psm1'
 
     # Version number of this module.
-    ModuleVersion         = '0.1.0'
+    ModuleVersion         = '0.1.1'
 
     # Supported PSEditions
     #CompatiblePSEditions = @("Desktop")

--- a/tests/Invoke-WTerraform.Tests.ps1
+++ b/tests/Invoke-WTerraform.Tests.ps1
@@ -23,7 +23,7 @@ Describe "Invoke-WTerraform" {
             Move-Item -LiteralPath $tempcachePath -Destination $cachePath
         }
     }
-    Context "Configured Folders" {
+    Context "Version for current Folder configured" {
         BeforeAll {
             $path = "TestDrive:\1"
             New-Item -Path $path -ItemType Directory
@@ -42,6 +42,23 @@ Describe "Invoke-WTerraform" {
         }
         it "Should work With alias" {
             $actualVersion = terraform -version
+            $actualVersion[0] | Should -Be "Terraform v0.14.0"
+        }
+        AfterAll {
+            Pop-Location
+            Pop-Location -ErrorAction SilentlyContinue
+        }
+    }
+
+    Context "Global Version configured" {
+        BeforeAll {
+            Set-WTerraformVersion -Version "0.14.0" -Global
+            $path = "TestDrive:\global"
+            New-Item -Path $path -ItemType Directory
+            Push-Location -Path $path
+        }
+        It "Should fallback to global version" {
+            $actualVersion = Invoke-WTerraform -version
             $actualVersion[0] | Should -Be "Terraform v0.14.0"
         }
         AfterAll {

--- a/tests/Set-WTerraformVersion.Tests.ps1
+++ b/tests/Set-WTerraformVersion.Tests.ps1
@@ -88,7 +88,7 @@ Describe "Set-WTerraformVersion global" {
             [System.Environment]::GetEnvironmentVariable("Path", [System.EnvironmentVariableTarget]::User) | Should -Not -BeLike "*$($versionPath)*"
         }
         It "Should reload Path" {
-            $env:Path | Should -BeLike "*$([System.Environment]::GetEnvironmentVariable("Path", [System.EnvironmentVariableTarget]::User))*"
+            $env:Path | Should -BeLike "*$([System.Environment]::GetEnvironmentVariable("Path", [System.EnvironmentVariableTarget]::User))"
         }
     }
 }

--- a/tests/Set-WTerraformVersion.Tests.ps1
+++ b/tests/Set-WTerraformVersion.Tests.ps1
@@ -87,5 +87,8 @@ Describe "Set-WTerraformVersion global" {
         It "Should remove old Version Folder from Path" {
             [System.Environment]::GetEnvironmentVariable("Path", [System.EnvironmentVariableTarget]::User) | Should -Not -BeLike "*$($versionPath)*"
         }
+        It "Should reload Path" {
+            $env:Path | Should -BeLike "*$([System.Environment]::GetEnvironmentVariable("Path", [System.EnvironmentVariableTarget]::User))*"
+        }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The global switch worked only when the module was not loaded as `terraform` autoloaded the module. Not the Module `Invoke-WTerraform` falls back to `terraform.exe` in Path.
Furthermore `Set-WTerraform -Global` now reloads the path

## Related Issue
fix #18 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Added Test for global fallback and path reload.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

